### PR TITLE
Add Doom Emacs

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -37,6 +37,7 @@
 
 ## CONFIGS
 
+- <https://github.com/hlissner/dotfiles>
 - <https://github.com/fufexan/dotfiles>
 - <https://github.com/leona-ya/nixfiles>
 - <https://github.com/isabelroses/dotfiles>

--- a/home/default.nix
+++ b/home/default.nix
@@ -5,6 +5,7 @@
     ./desktop-env
     ./desktop-hypr
     ./desktop-wayland
+    ./emacs
     ./git
     ./mail
     ./media

--- a/home/desktop-hypr/hyprland.nix
+++ b/home/desktop-hypr/hyprland.nix
@@ -119,7 +119,7 @@
       ];
       #
       # # See https://wiki.hyprland.org/Configuring/Keywords/ for more
-      "$mainMod" = "ALT";
+      "$mainMod" = "SUPER";
       #
       # # Example binds, see https://wiki.hyprland.org/Configuring/Binds/ for more
       # # For dispatchers, see https://wiki.hyprland.org/Configuring/Dispatchers/

--- a/home/emacs/README.md
+++ b/home/emacs/README.md
@@ -1,0 +1,18 @@
+# DOOM Emacs
+
+- [Doom Emacs](https://github.com/doomemacs/doomemacs)
+- [Doom Emacs Keybinding Reference](https://discourse.doomemacs.org/t/keybind-reference-sheet/49)
+
+## Org-Mode & Org-Roam
+
+- [Org-Mode](https://orgmode.org/manual/)
+- [The Beautiful Nightmare that is Org Mode](https://github.com/james-stoup/emacs-org-mode-tutorial/)
+- [Org-Roam](https://www.orgroam.com/manual.html)
+- [Hitchhiker's Rough Guide to Org roam V2](https://github.com/org-roam/org-roam/wiki/Hitchhiker's-Rough-Guide-to-Org-roam-V2)
+
+## TODO
+
+- [org-modern](https://github.com/minad/org-modern)
+- [org-fancy-priorities](https://github.com/harrybournis/org-fancy-priorities)
+- [org-super-agenda](https://github.com/alphapapa/org-super-agenda)
+- [doom emacs :biblio](https://github.com/doomemacs/doomemacs/blob/master/modules/tools/biblio/README.org)

--- a/home/emacs/default.nix
+++ b/home/emacs/default.nix
@@ -1,4 +1,8 @@
-{config,pkgs,...}:{
+{
+  config,
+  pkgs,
+  ...
+}: {
   ## TODO: https://github.com/nix-community/emacs-overlay
   ## NOTE: manual setup for doomemacs required
   ## git clone --depth 1 https://github.com/doomemacs/doomemacs $XDG_CONFIG_HOME/emacs
@@ -19,33 +23,31 @@
     socketActivation.enable = true;
   };
 
-  home.sessionPath = [ "$XDG_CONFIG_HOME/emacs/bin" ];
+  home.sessionPath = ["$XDG_CONFIG_HOME/emacs/bin"];
 
-  ## TODO: when done configuring:
-  ## write doom config!
-
-  ## https://bhankas.org/blog/deploying_doom_emacs_config_via_nixos_home_manager/
-  ## https://discourse.nixos.org/t/advice-needed-installing-doom-emacs/8806/8
-  ## https://discourse.doomemacs.org/t/installing-doom-emacs-on-nixos/4600/2
-  ## https://github.com/hlissner/dotfiles/blob/531e90f4e5e27a13f23ad2d8adf2f2f57aa0c08a/modules/editors/emacs.nix#L4
-  ##
-  # xdg = {
-  #   configFile = {
-  #     "emacs" = {
-  #       source = pkgs.fetchFromGitHub {
-  #         owner = "hlissner";
-  #         repo = "doom-emacs";
-  #         rev = "master";
-  #         hash = "sha256-sebujw5VvBWMS+wXyjiGF81iyjPM/QQDnw5l7tDJCvk=";
-  #       };
-  #       # onChange = "${pkgs.writeShellScript "doom-change" ''
-  #       #   if [ ! -d "${config.xdg.configHome}/doom" ]; then
-  #       #     ${config.xdg.configHome}/emacs/bin/doom -y install
-  #       #   else
-  #       #     ${config.xdg.configHome}/emacs/bin/doom -y sync -u
-  #       #   fi
-  #       # ''}";
-  #     };
-  #   };
-  # };
+  ## BUG:
+  ## https://github.com/nix-community/home-manager/pull/1455#issuecomment-681041818
+  ## https://github.com/nix-community/home-manager/issues/3514#issuecomment-2541776151
+  xdg.configFile = {
+    doom = {
+      source = config.lib.file.mkOutOfStoreSymlink ./doom;
+      onChange = "${config.xdg.configHome}/doom sync";
+    };
+    # emacs = let
+    #   doom-emacs = pkgs.fetchFromGitHub {
+    #     owner = "hlissner";
+    #     repo = "doom-emacs";
+    #     rev = "master";
+    #     hash = "sha256-sebujw5VvBWMS+wXyjiGF81iyjPM/QQDnw5l7tDJCvk=";
+    #   };
+    # in {
+    #   source = config.lib.file.mkOutOfStoreSymlink doom-emacs;
+    #   #   if [ ! -d "${config.xdg.configHome}/doom" ]; then
+    #   #     ${config.xdg.configHome}/emacs/bin/doom -y install
+    #   #   else
+    #   #     ${config.xdg.configHome}/emacs/bin/doom -y sync -u
+    #   #   fi
+    #   # ''}";
+    # };
+  };
 }

--- a/home/emacs/default.nix
+++ b/home/emacs/default.nix
@@ -30,13 +30,13 @@
   ## https://github.com/nix-community/home-manager/issues/3514#issuecomment-2541776151
   xdg.configFile = {
     doom = {
-      source = config.lib.file.mkOutOfStoreSymlink ./doom;
+      source = ./doom;
       onChange = "${config.xdg.configHome}/doom sync";
     };
     # emacs = let
     #   doom-emacs = pkgs.fetchFromGitHub {
-    #     owner = "hlissner";
     #     repo = "doom-emacs";
+    #     owner = "hlissner";
     #     rev = "master";
     #     hash = "sha256-sebujw5VvBWMS+wXyjiGF81iyjPM/QQDnw5l7tDJCvk=";
     #   };

--- a/home/emacs/default.nix
+++ b/home/emacs/default.nix
@@ -1,0 +1,54 @@
+{config,pkgs,...}:{
+  ## TODO: https://github.com/nix-community/emacs-overlay
+  ## NOTE: manual setup for doomemacs required
+  ## git clone --depth 1 https://github.com/doomemacs/doomemacs $XDG_CONFIG_HOME/emacs
+  ## $XDG_CONFIG_HOME/emacs/bin/doom install
+  ## NOTE: requires to run `doom sync && systemctl --user restart emacs` after change
+  programs.emacs = {
+    enable = true;
+    package = pkgs.emacs;
+    extraPackages = epkgs: [
+
+    ]; 
+  };
+
+  services.emacs = {
+    enable = true;
+    extraOptions = [
+      "--init-directory=${config.xdg.configHome}/emacs"
+    ];
+    startWithUserSession = "graphical";
+    client.enable = true;
+    socketActivation.enable = true;
+  };
+
+  home.sessionPath = [ "$XDG_CONFIG_HOME/emacs/bin" ];
+
+  ## TODO: when done configuring:
+  ## write doom config!
+
+  ## https://bhankas.org/blog/deploying_doom_emacs_config_via_nixos_home_manager/
+  ## https://discourse.nixos.org/t/advice-needed-installing-doom-emacs/8806/8
+  ## https://discourse.doomemacs.org/t/installing-doom-emacs-on-nixos/4600/2
+  ## https://github.com/hlissner/dotfiles/blob/531e90f4e5e27a13f23ad2d8adf2f2f57aa0c08a/modules/editors/emacs.nix#L4
+  ##
+  # xdg = {
+  #   configFile = {
+  #     "emacs" = {
+  #       source = pkgs.fetchFromGitHub {
+  #         owner = "hlissner";
+  #         repo = "doom-emacs";
+  #         rev = "master";
+  #         hash = "sha256-sebujw5VvBWMS+wXyjiGF81iyjPM/QQDnw5l7tDJCvk=";
+  #       };
+  #       # onChange = "${pkgs.writeShellScript "doom-change" ''
+  #       #   if [ ! -d "${config.xdg.configHome}/doom" ]; then
+  #       #     ${config.xdg.configHome}/emacs/bin/doom -y install
+  #       #   else
+  #       #     ${config.xdg.configHome}/emacs/bin/doom -y sync -u
+  #       #   fi
+  #       # ''}";
+  #     };
+  #   };
+  # };
+}

--- a/home/emacs/default.nix
+++ b/home/emacs/default.nix
@@ -3,13 +3,10 @@
   ## NOTE: manual setup for doomemacs required
   ## git clone --depth 1 https://github.com/doomemacs/doomemacs $XDG_CONFIG_HOME/emacs
   ## $XDG_CONFIG_HOME/emacs/bin/doom install
-  ## NOTE: requires to run `doom sync && systemctl --user restart emacs` after change
   programs.emacs = {
     enable = true;
     package = pkgs.emacs;
-    extraPackages = epkgs: [
-
-    ]; 
+    extraPackages = epkgs: [];
   };
 
   services.emacs = {

--- a/home/emacs/doom/config.el
+++ b/home/emacs/doom/config.el
@@ -1,0 +1,19 @@
+;; There are two ways to load a theme. Both assume the theme is installed and
+;; available. You can either set `doom-theme' or manually load a theme with the
+;; `load-theme' function. This is the default:
+(setq doom-theme 'modus-vivendi)
+
+;; This determines the style of line numbers in effect. If set to `nil', line
+;; numbers are disabled. For relative line numbers, set this to `relative'.
+(setq display-line-numbers-type relative)
+
+;; This globally displays a column indicator at column 80
+(setq global-display-fill-column-indicator-mode)
+
+;; If you use `org' and don't want your org files in the default location below,
+;; change `org-directory'. It must be set before org loads!
+(setq org-directory "~/org/")
+
+;(setq projectile-project-search-path "$XDG_PROJECT_DIR")
+(setq projectile-project-search-path '("~/prj/"))
+

--- a/home/emacs/doom/config.el
+++ b/home/emacs/doom/config.el
@@ -1,84 +1,65 @@
 ;;; $DOOMDIR/config.el -*- lexical-binding: t; -*-
 
-;; Place your private configuration here! Remember, you do not need to run 'doom
-;; sync' after modifying this file!
+;; User
+(setq user-full-name "psychosis448")
 
+;; Theme
+(load-theme 'modus-vivendi t)
 
-;; Some functionality uses this to identify you, e.g. GPG configuration, email
-;; clients, file templates and snippets. It is optional.
-;; (setq user-full-name "John Doe"
-;;       user-mail-address "john@doe.com")
-
-;; Doom exposes five (optional) variables for controlling fonts in Doom:
-;;
-;; - `doom-font' -- the primary font to use
-;; - `doom-variable-pitch-font' -- a non-monospace font (where applicable)
-;; - `doom-big-font' -- used for `doom-big-font-mode'; use this for
-;;   presentations or streaming.
-;; - `doom-symbol-font' -- for symbols
-;; - `doom-serif-font' -- for the `fixed-pitch-serif' face
-;;
-;; See 'C-h v doom-font' for documentation and more examples of what they
-;; accept. For example:
-;;
-;; Use default system font, but increase size to 20
+;; Font
 (setq doom-font (font-spec :family nil :size 20))
-;;
-;; If you or Emacs can't find your font, use 'M-x describe-font' to look them
-;; up, `M-x eval-region' to execute elisp code, and 'M-x doom/reload-font' to
-;; refresh your font settings. If Emacs still can't find your font, it likely
-;; wasn't installed correctly. Font issues are rarely Doom issues!
 
-;; There are two ways to load a theme. Both assume the theme is installed and
-;; available. You can either set `doom-theme' or manually load a theme with the
-;; `load-theme' function. This is the default:
-(setq doom-theme 'modus-vivendi)
-
-;; This determines the style of line numbers in effect. If set to `nil', line
-;; numbers are disabled. For relative line numbers, set this to `relative'.
+;; Text Display
 (setq display-line-numbers-type 'relative)
+(setopt global-display-fill-column-indicator-mode 80)
+(add-hook 'text-mode-hook 'turn-on-visual-line-mode)
+(add-hook 'text-mode-hook #'visual-fill-column-mode)
 
-;; This globally displays a column indicator at column 80
-(setq global-display-fill-column-indicator-mode 80)
+;; Projectile
+(setq projectile-project-search-path '("~/org/" "~/sys/"))
 
-;; If you use `org' and don't want your org files in the default location below,
-;; change `org-directory'. It must be set before org loads!
-;; (setq org-directory "$XDG_ORG_DIR")
+;; Org & Org-Roam Directories
 (setq org-directory "~/org/")
 (setq org-roam-directory org-directory)
-(setq org-roam-dailies-directory "0-inbox")
 
-;; (setq projectile-project-search-path "$XDG_PROJECT_DIR")
-(setq projectile-project-search-path '("~/prj/"))
+(after! org
+  :config
+  (setq org-log-done 'time)
+  (setq org-todo-keywords
+        '((sequence
+           "PROJ(p)"  ; A project, which usually contains other tasks
+           "LOOP(r)"  ; A recurring task
+           "TODO(t)"  ; A task that needs doing & is ready to do
+           "STRT(s!)"  ; A task that is in progress
+           "WAIT(w@/!)"  ; Something external is holding up this task
+           "HOLD(h@/!)"  ; This task is paused/on hold because of me
+           "IDEA(i@)"  ; An unconfirmed and unapproved task or notion
+           "|"
+           "DONE(d!)"  ; Task successfully completed
+           "KILL(k@/!)") ; Task was cancelled, aborted, or is no longer applicable
+          )
+        org-todo-keyword-faces
+        '(("STRT" . +org-todo-active)
+          ("WAIT" . +org-todo-onhold)
+          ("HOLD" . +org-todo-onhold)
+          ("PROJ" . +org-todo-project)
+          ("KILL" . +org-todo-cancel)))
+  )
 
-;; Whenever you reconfigure a package, make sure to wrap your config in an
-;; `after!' block, otherwise Doom's defaults may override your settings. E.g.
-;;
-;;   (after! PACKAGE
-;;     (setq x y))
-;;
-;; The exceptions to this rule:
-;;
-;;   - Setting file/directory variables (like `org-directory')
-;;   - Setting variables which explicitly tell you to set them before their
-;;     package is loaded (see 'C-h v VARIABLE' to look up their documentation).
-;;   - Setting doom variables (which start with 'doom-' or '+').
-;;
-;; Here are some additional functions/macros that will help you configure Doom.
-;;
-;; - `load!' for loading external *.el files relative to this one
-;; - `use-package!' for configuring packages
-;; - `after!' for running code after a package has loaded
-;; - `add-load-path!' for adding directories to the `load-path', relative to
-;;   this file. Emacs searches the `load-path' when you load packages with
-;;   `require' or `use-package'.
-;; - `map!' for binding new keys
-;;
-;; To get information about any of these functions/macros, move the cursor over
-;; the highlighted symbol at press 'K' (non-evil users must press 'C-c c k').
-;; This will open documentation for it, including demos of how they are used.
-;; Alternatively, use `C-h o' to look up a symbol (functions, variables, faces,
-;; etc).
-;;
-;; You can also try 'gd' (or 'C-c c d') to jump to their definition and see how
-;; they are implemented.
+(after! org-roam
+  :config
+  (setq org-roam-dailies-directory "0-inbox")
+  ;; https://github.com/org-roam/org-roam/blob/main/org-roam-capture.el
+  (setopt org-roam-capture-templates
+          '(("d" "default" plain "%?"
+             :target (file+head "${slug}.org"
+                                "#+title: ${title}\n")
+             :unnarrowed t)
+
+            ("l" "literature" plain "%?"
+             :target (file+head "%^{author}%^{year}-%^{title}.org"
+                                "#+title: ${title}\n#+filetags: literature")
+             :unnarrowed t)
+            )
+          )
+  )

--- a/home/emacs/doom/config.el
+++ b/home/emacs/doom/config.el
@@ -1,3 +1,34 @@
+;;; $DOOMDIR/config.el -*- lexical-binding: t; -*-
+
+;; Place your private configuration here! Remember, you do not need to run 'doom
+;; sync' after modifying this file!
+
+
+;; Some functionality uses this to identify you, e.g. GPG configuration, email
+;; clients, file templates and snippets. It is optional.
+;; (setq user-full-name "John Doe"
+;;       user-mail-address "john@doe.com")
+
+;; Doom exposes five (optional) variables for controlling fonts in Doom:
+;;
+;; - `doom-font' -- the primary font to use
+;; - `doom-variable-pitch-font' -- a non-monospace font (where applicable)
+;; - `doom-big-font' -- used for `doom-big-font-mode'; use this for
+;;   presentations or streaming.
+;; - `doom-symbol-font' -- for symbols
+;; - `doom-serif-font' -- for the `fixed-pitch-serif' face
+;;
+;; See 'C-h v doom-font' for documentation and more examples of what they
+;; accept. For example:
+;;
+;; Use default system font, but increase size to 20
+(setq doom-font (font-spec :family nil :size 20))
+;;
+;; If you or Emacs can't find your font, use 'M-x describe-font' to look them
+;; up, `M-x eval-region' to execute elisp code, and 'M-x doom/reload-font' to
+;; refresh your font settings. If Emacs still can't find your font, it likely
+;; wasn't installed correctly. Font issues are rarely Doom issues!
+
 ;; There are two ways to load a theme. Both assume the theme is installed and
 ;; available. You can either set `doom-theme' or manually load a theme with the
 ;; `load-theme' function. This is the default:
@@ -5,15 +36,49 @@
 
 ;; This determines the style of line numbers in effect. If set to `nil', line
 ;; numbers are disabled. For relative line numbers, set this to `relative'.
-(setq display-line-numbers-type relative)
+(setq display-line-numbers-type 'relative)
 
 ;; This globally displays a column indicator at column 80
-(setq global-display-fill-column-indicator-mode)
+(setq global-display-fill-column-indicator-mode 80)
 
 ;; If you use `org' and don't want your org files in the default location below,
 ;; change `org-directory'. It must be set before org loads!
+;; (setq org-directory "$XDG_ORG_DIR")
 (setq org-directory "~/org/")
+(setq org-roam-directory org-directory)
+(setq org-roam-dailies-directory "0-inbox")
 
-;(setq projectile-project-search-path "$XDG_PROJECT_DIR")
+;; (setq projectile-project-search-path "$XDG_PROJECT_DIR")
 (setq projectile-project-search-path '("~/prj/"))
 
+;; Whenever you reconfigure a package, make sure to wrap your config in an
+;; `after!' block, otherwise Doom's defaults may override your settings. E.g.
+;;
+;;   (after! PACKAGE
+;;     (setq x y))
+;;
+;; The exceptions to this rule:
+;;
+;;   - Setting file/directory variables (like `org-directory')
+;;   - Setting variables which explicitly tell you to set them before their
+;;     package is loaded (see 'C-h v VARIABLE' to look up their documentation).
+;;   - Setting doom variables (which start with 'doom-' or '+').
+;;
+;; Here are some additional functions/macros that will help you configure Doom.
+;;
+;; - `load!' for loading external *.el files relative to this one
+;; - `use-package!' for configuring packages
+;; - `after!' for running code after a package has loaded
+;; - `add-load-path!' for adding directories to the `load-path', relative to
+;;   this file. Emacs searches the `load-path' when you load packages with
+;;   `require' or `use-package'.
+;; - `map!' for binding new keys
+;;
+;; To get information about any of these functions/macros, move the cursor over
+;; the highlighted symbol at press 'K' (non-evil users must press 'C-c c k').
+;; This will open documentation for it, including demos of how they are used.
+;; Alternatively, use `C-h o' to look up a symbol (functions, variables, faces,
+;; etc).
+;;
+;; You can also try 'gd' (or 'C-c c d') to jump to their definition and see how
+;; they are implemented.

--- a/home/emacs/doom/init.el
+++ b/home/emacs/doom/init.el
@@ -35,7 +35,7 @@
        ;;doom-quit         ; DOOM quit-message prompts when you quit Emacs
        ;;(emoji +unicode)  ; 🙂
        hl-todo           ; highlight TODO/FIXME/NOTE/DEPRECATED/HACK/REVIEW
-       ;;indent-guides     ; highlighted indent columns
+       indent-guides     ; highlighted indent columns
        ;;ligatures         ; ligatures and symbols to make your code pretty again
        ;;minimap           ; show a map of the code on the side
        modeline          ; snazzy, Atom-inspired modeline, plus API
@@ -44,7 +44,7 @@
        ophints           ; highlight the region an operation acts on
        (popup +defaults)   ; tame sudden yet inevitable temporary windows
        ;;tabs              ; a tab bar for Emacs
-       ;;treemacs          ; a project drawer, like neotree but cooler
+       treemacs          ; a project drawer, like neotree but cooler
        ;;unicode           ; extended unicode support for various languages
        (vc-gutter +pretty) ; vcs diff in the fringe
        vi-tilde-fringe   ; fringe tildes to mark beyond EOB
@@ -56,7 +56,7 @@
        (evil +everywhere); come to the dark side, we have cookies
        file-templates    ; auto-snippets for empty files
        fold              ; (nigh) universal code folding
-       ;;(format +onsave)  ; automated prettiness
+       (format +onsave)  ; automated prettiness
        ;;god               ; run Emacs commands without modifier keys
        ;;lispy             ; vim for lisp, for people who don't like vim
        ;;multiple-cursors  ; editing in many places at once
@@ -75,7 +75,7 @@
        vc                ; version-control and Emacs, sitting in a tree
 
        :term
-       ;;eshell            ; the elisp shell that works everywhere
+       eshell            ; the elisp shell that works everywhere
        ;;shell             ; simple shell REPL for Emacs
        ;;term              ; basic terminal emulator for Emacs
        ;;vterm             ; the best terminal emulation in Emacs
@@ -148,11 +148,11 @@
        ;;lean              ; for folks with too much to prove
        ;;ledger            ; be audit you can be
        ;;lua               ; one-based indices? one-based indices
-       markdown          ; writing docs for people to ignore
+       markdown            ; writing docs for people to ignore
        ;;nim               ; python + lisp at the speed of c
        ;;nix               ; I hereby declare "nix geht mehr!"
        ;;ocaml             ; an objective camel
-       org               ; organize your plain life in plain text
+       (org +roam2)        ; organize your plain life in plain text
        ;;php               ; perl's insecure younger brother
        ;;plantuml          ; diagrams for confusing people more
        ;;graphviz          ; diagrams for confusing yourself even more

--- a/home/emacs/doom/init.el
+++ b/home/emacs/doom/init.el
@@ -1,0 +1,193 @@
+;;; init.el -*- lexical-binding: t; -*-
+
+;; This file controls what Doom modules are enabled and what order they load
+;; in. Remember to run 'doom sync' after modifying it!
+
+;; NOTE Press 'SPC h d h' (or 'C-h d h' for non-vim users) to access Doom's
+;;      documentation. There you'll find a link to Doom's Module Index where all
+;;      of our modules are listed, including what flags they support.
+
+;; NOTE Move your cursor over a module's name (or its flags) and press 'K' (or
+;;      'C-c c k' for non-vim users) to view its documentation. This works on
+;;      flags as well (those symbols that start with a plus).
+;;
+;;      Alternatively, press 'gd' (or 'C-c c d') on a module to browse its
+;;      directory (for easy access to its source code).
+
+(doom! :input
+       ;;bidi              ; (tfel ot) thgir etirw uoy gnipleh
+       ;;chinese
+       ;;japanese
+       ;;layout            ; auie,ctsrnm is the superior home row
+
+       :completion
+       ;;company           ; the ultimate code completion backend
+       (corfu +orderless)  ; complete with cap(f), cape and a flying feather!
+       ;;helm              ; the *other* search engine for love and life
+       ;;ido               ; the other *other* search engine...
+       ;;ivy               ; a search engine for love and life
+       vertico           ; the search engine of the future
+
+       :ui
+       ;;deft              ; notational velocity for Emacs
+       doom              ; what makes DOOM look the way it does
+       doom-dashboard    ; a nifty splash screen for Emacs
+       ;;doom-quit         ; DOOM quit-message prompts when you quit Emacs
+       ;;(emoji +unicode)  ; 🙂
+       hl-todo           ; highlight TODO/FIXME/NOTE/DEPRECATED/HACK/REVIEW
+       ;;indent-guides     ; highlighted indent columns
+       ;;ligatures         ; ligatures and symbols to make your code pretty again
+       ;;minimap           ; show a map of the code on the side
+       modeline          ; snazzy, Atom-inspired modeline, plus API
+       ;;nav-flash         ; blink cursor line after big motions
+       ;;neotree           ; a project drawer, like NERDTree for vim
+       ophints           ; highlight the region an operation acts on
+       (popup +defaults)   ; tame sudden yet inevitable temporary windows
+       ;;tabs              ; a tab bar for Emacs
+       ;;treemacs          ; a project drawer, like neotree but cooler
+       ;;unicode           ; extended unicode support for various languages
+       (vc-gutter +pretty) ; vcs diff in the fringe
+       vi-tilde-fringe   ; fringe tildes to mark beyond EOB
+       ;;window-select     ; visually switch windows
+       workspaces        ; tab emulation, persistence & separate workspaces
+       zen               ; distraction-free coding or writing
+
+       :editor
+       (evil +everywhere); come to the dark side, we have cookies
+       file-templates    ; auto-snippets for empty files
+       fold              ; (nigh) universal code folding
+       ;;(format +onsave)  ; automated prettiness
+       ;;god               ; run Emacs commands without modifier keys
+       ;;lispy             ; vim for lisp, for people who don't like vim
+       ;;multiple-cursors  ; editing in many places at once
+       ;;objed             ; text object editing for the innocent
+       ;;parinfer          ; turn lisp into python, sort of
+       ;;rotate-text       ; cycle region at point between text candidates
+       snippets          ; my elves. They type so I don't have to
+       ;;word-wrap         ; soft wrapping with language-aware indent
+
+       :emacs
+       dired             ; making dired pretty [functional]
+       electric          ; smarter, keyword-based electric-indent
+       ;;eww               ; the internet is gross
+       ;;ibuffer           ; interactive buffer management
+       undo              ; persistent, smarter undo for your inevitable mistakes
+       vc                ; version-control and Emacs, sitting in a tree
+
+       :term
+       ;;eshell            ; the elisp shell that works everywhere
+       ;;shell             ; simple shell REPL for Emacs
+       ;;term              ; basic terminal emulator for Emacs
+       ;;vterm             ; the best terminal emulation in Emacs
+
+       :checkers
+       syntax              ; tasing you for every semicolon you forget
+       ;;(spell +flyspell) ; tasing you for misspelling mispelling
+       ;;grammar           ; tasing grammar mistake every you make
+
+       :tools
+       ;;ansible
+       ;;biblio            ; Writes a PhD for you (citation needed)
+       ;;collab            ; buffers with friends
+       ;;debugger          ; FIXME stepping through code, to help you add bugs
+       ;;direnv
+       ;;docker
+       ;;editorconfig      ; let someone else argue about tabs vs spaces
+       ;;ein               ; tame Jupyter notebooks with emacs
+       (eval +overlay)     ; run code, run (also, repls)
+       lookup              ; navigate your code and its documentation
+       ;;lsp               ; M-x vscode
+       magit             ; a git porcelain for Emacs
+       ;;make              ; run make tasks from Emacs
+       ;;pass              ; password manager for nerds
+       ;;pdf               ; pdf enhancements
+       ;;prodigy           ; FIXME managing external services & code builders
+       ;;terraform         ; infrastructure as code
+       ;;tmux              ; an API for interacting with tmux
+       ;;tree-sitter       ; syntax and parsing, sitting in a tree...
+       ;;upload            ; map local to remote projects via ssh/ftp
+
+       :os
+       (:if (featurep :system 'macos) macos)  ; improve compatibility with macOS
+       ;;tty               ; improve the terminal Emacs experience
+
+       :lang
+       ;;agda              ; types of types of types of types...
+       ;;beancount         ; mind the GAAP
+       ;;(cc +lsp)         ; C > C++ == 1
+       ;;clojure           ; java with a lisp
+       ;;common-lisp       ; if you've seen one lisp, you've seen them all
+       ;;coq               ; proofs-as-programs
+       ;;crystal           ; ruby at the speed of c
+       ;;csharp            ; unity, .NET, and mono shenanigans
+       ;;data              ; config/data formats
+       ;;(dart +flutter)   ; paint ui and not much else
+       ;;dhall
+       ;;elixir            ; erlang done right
+       ;;elm               ; care for a cup of TEA?
+       emacs-lisp        ; drown in parentheses
+       ;;erlang            ; an elegant language for a more civilized age
+       ;;ess               ; emacs speaks statistics
+       ;;factor
+       ;;faust             ; dsp, but you get to keep your soul
+       ;;fortran           ; in FORTRAN, GOD is REAL (unless declared INTEGER)
+       ;;fsharp            ; ML stands for Microsoft's Language
+       ;;fstar             ; (dependent) types and (monadic) effects and Z3
+       ;;gdscript          ; the language you waited for
+       ;;(go +lsp)         ; the hipster dialect
+       ;;(graphql +lsp)    ; Give queries a REST
+       ;;(haskell +lsp)    ; a language that's lazier than I am
+       ;;hy                ; readability of scheme w/ speed of python
+       ;;idris             ; a language you can depend on
+       ;;json              ; At least it ain't XML
+       ;;(java +lsp)       ; the poster child for carpal tunnel syndrome
+       ;;javascript        ; all(hope(abandon(ye(who(enter(here))))))
+       ;;julia             ; a better, faster MATLAB
+       ;;kotlin            ; a better, slicker Java(Script)
+       ;;latex             ; writing papers in Emacs has never been so fun
+       ;;lean              ; for folks with too much to prove
+       ;;ledger            ; be audit you can be
+       ;;lua               ; one-based indices? one-based indices
+       markdown          ; writing docs for people to ignore
+       ;;nim               ; python + lisp at the speed of c
+       ;;nix               ; I hereby declare "nix geht mehr!"
+       ;;ocaml             ; an objective camel
+       org               ; organize your plain life in plain text
+       ;;php               ; perl's insecure younger brother
+       ;;plantuml          ; diagrams for confusing people more
+       ;;graphviz          ; diagrams for confusing yourself even more
+       ;;purescript        ; javascript, but functional
+       ;;python            ; beautiful is better than ugly
+       ;;qt                ; the 'cutest' gui framework ever
+       ;;racket            ; a DSL for DSLs
+       ;;raku              ; the artist formerly known as perl6
+       ;;rest              ; Emacs as a REST client
+       ;;rst               ; ReST in peace
+       ;;(ruby +rails)     ; 1.step {|i| p "Ruby is #{i.even? ? 'love' : 'life'}"}
+       ;;(rust +lsp)       ; Fe2O3.unwrap().unwrap().unwrap().unwrap()
+       ;;scala             ; java, but good
+       ;;(scheme +guile)   ; a fully conniving family of lisps
+       sh                ; she sells {ba,z,fi}sh shells on the C xor
+       ;;sml
+       ;;solidity          ; do you need a blockchain? No.
+       ;;swift             ; who asked for emoji variables?
+       ;;terra             ; Earth and Moon in alignment for performance.
+       ;;web               ; the tubes
+       ;;yaml              ; JSON, but readable
+       ;;zig               ; C, but simpler
+
+       :email
+       ;;(mu4e +org +gmail)
+       ;;notmuch
+       ;;(wanderlust +gmail)
+
+       :app
+       ;;calendar
+       ;;emms
+       ;;everywhere        ; *leave* Emacs!? You must be joking
+       ;;irc               ; how neckbeards socialize
+       ;;(rss +org)        ; emacs as an RSS reader
+
+       :config
+       ;;literate
+       (default +bindings +smartparens))

--- a/home/emacs/doom/init.el
+++ b/home/emacs/doom/init.el
@@ -43,7 +43,7 @@
        ;;neotree           ; a project drawer, like NERDTree for vim
        ophints           ; highlight the region an operation acts on
        (popup +defaults)   ; tame sudden yet inevitable temporary windows
-       ;;tabs              ; a tab bar for Emacs
+       tabs              ; a tab bar for Emacs
        treemacs          ; a project drawer, like neotree but cooler
        ;;unicode           ; extended unicode support for various languages
        (vc-gutter +pretty) ; vcs diff in the fringe
@@ -87,7 +87,7 @@
 
        :tools
        ;;ansible
-       ;;biblio            ; Writes a PhD for you (citation needed)
+       biblio            ; Writes a PhD for you (citation needed)
        ;;collab            ; buffers with friends
        ;;debugger          ; FIXME stepping through code, to help you add bugs
        ;;direnv

--- a/home/emacs/doom/packages.el
+++ b/home/emacs/doom/packages.el
@@ -1,0 +1,1 @@
+(package! modus-themes)

--- a/home/emacs/doom/packages.el
+++ b/home/emacs/doom/packages.el
@@ -3,48 +3,4 @@
 
 ;; To install a package with Doom you must declare them here and run 'doom sync'
 ;; on the command line, then restart Emacs for the changes to take effect -- or
-
 (package! modus-themes)
-
-;; To install SOME-PACKAGE from MELPA, ELPA or emacsmirror:
-;; (package! some-package)
-
-;; To install a package directly from a remote git repo, you must specify a
-;; `:recipe'. You'll find documentation on what `:recipe' accepts here:
-;; https://github.com/radian-software/straight.el#the-recipe-format
-;; (package! another-package
-;;   :recipe (:host github :repo "username/repo"))
-
-;; If the package you are trying to install does not contain a PACKAGENAME.el
-;; file, or is located in a subdirectory of the repo, you'll need to specify
-;; `:files' in the `:recipe':
-;; (package! this-package
-;;   :recipe (:host github :repo "username/repo"
-;;            :files ("some-file.el" "src/lisp/*.el")))
-
-;; If you'd like to disable a package included with Doom, you can do so here
-;; with the `:disable' property:
-;; (package! builtin-package :disable t)
-
-;; You can override the recipe of a built in package without having to specify
-;; all the properties for `:recipe'. These will inherit the rest of its recipe
-;; from Doom or MELPA/ELPA/Emacsmirror:
-;; (package! builtin-package :recipe (:nonrecursive t))
-;; (package! builtin-package-2 :recipe (:repo "myfork/package"))
-
-;; Specify a `:branch' to install a package from a particular branch or tag.
-;; This is required for some packages whose default branch isn't 'master' (which
-;; our package manager can't deal with; see radian-software/straight.el#279)
-;; (package! builtin-package :recipe (:branch "develop"))
-
-;; Use `:pin' to specify a particular commit to install.
-;; (package! builtin-package :pin "1a2b3c4d5e")
-
-
-;; Doom's packages are pinned to a specific commit and updated from release to
-;; release. The `unpin!' macro allows you to unpin single packages...
-;; (unpin! pinned-package)
-;; ...or multiple packages
-;; (unpin! pinned-package another-pinned-package)
-;; ...Or *all* packages (NOT RECOMMENDED; will likely break things)
-;; (unpin! t)

--- a/home/emacs/doom/packages.el
+++ b/home/emacs/doom/packages.el
@@ -1,1 +1,50 @@
+;; -*- no-byte-compile: t; -*-
+;;; $DOOMDIR/packages.el
+
+;; To install a package with Doom you must declare them here and run 'doom sync'
+;; on the command line, then restart Emacs for the changes to take effect -- or
+
 (package! modus-themes)
+
+;; To install SOME-PACKAGE from MELPA, ELPA or emacsmirror:
+;; (package! some-package)
+
+;; To install a package directly from a remote git repo, you must specify a
+;; `:recipe'. You'll find documentation on what `:recipe' accepts here:
+;; https://github.com/radian-software/straight.el#the-recipe-format
+;; (package! another-package
+;;   :recipe (:host github :repo "username/repo"))
+
+;; If the package you are trying to install does not contain a PACKAGENAME.el
+;; file, or is located in a subdirectory of the repo, you'll need to specify
+;; `:files' in the `:recipe':
+;; (package! this-package
+;;   :recipe (:host github :repo "username/repo"
+;;            :files ("some-file.el" "src/lisp/*.el")))
+
+;; If you'd like to disable a package included with Doom, you can do so here
+;; with the `:disable' property:
+;; (package! builtin-package :disable t)
+
+;; You can override the recipe of a built in package without having to specify
+;; all the properties for `:recipe'. These will inherit the rest of its recipe
+;; from Doom or MELPA/ELPA/Emacsmirror:
+;; (package! builtin-package :recipe (:nonrecursive t))
+;; (package! builtin-package-2 :recipe (:repo "myfork/package"))
+
+;; Specify a `:branch' to install a package from a particular branch or tag.
+;; This is required for some packages whose default branch isn't 'master' (which
+;; our package manager can't deal with; see radian-software/straight.el#279)
+;; (package! builtin-package :recipe (:branch "develop"))
+
+;; Use `:pin' to specify a particular commit to install.
+;; (package! builtin-package :pin "1a2b3c4d5e")
+
+
+;; Doom's packages are pinned to a specific commit and updated from release to
+;; release. The `unpin!' macro allows you to unpin single packages...
+;; (unpin! pinned-package)
+;; ...or multiple packages
+;; (unpin! pinned-package another-pinned-package)
+;; ...Or *all* packages (NOT RECOMMENDED; will likely break things)
+;; (unpin! t)


### PR DESCRIPTION
Add configuration for doom emacs

## Goals

- Have as much as possible automatically set up.
- But without compromising flexibility and functionality (e.g. don't manage emacs packages with nix, but let straight handle them instead)