### PR TITLE
Add initial nvim orgmode/org-roam config

### DIFF
--- a/home/nvim/README.md
+++ b/home/nvim/README.md
@@ -11,3 +11,5 @@ with [Home Manager](https://nix-community.github.io/home-manager/).
 
 - [nvim-orgmode](https://github.com/nvim-orgmode/orgmode)
 - [org-roam.nvim](https://github.com/chipsenkbeil/org-roam.nvim?tab=readme-ov-file)
+- [nvim-epub](https://github.com/CrystalDime/epub.nvim)
+- LaTeX

--- a/home/nvim/default.nix
+++ b/home/nvim/default.nix
@@ -100,6 +100,10 @@
       ## neogit
       neogit
       diffview-nvim
+
+      ## orgmode
+      orgmode
+      org-roam-nvim
     ];
 
     extraLuaConfig = ''

--- a/home/nvim/lua/plugins/orgmode.lua
+++ b/home/nvim/lua/plugins/orgmode.lua
@@ -1,0 +1,32 @@
+return {
+  {
+    "nvim-orgmode/orgmode",
+    event = 'VeryLazy',
+    ft = { 'org' },
+    opts = function()
+      require('orgmode').setup({
+        org_agenda_files = '~/org/**/*',
+        org_default_notes_file = '~/org/notes.org',
+      })
+    end,
+  },
+  {
+    "chipsenkbeil/org-roam.nvim",
+    dependencies = {
+      "nvim-orgmode/orgmode",
+    },
+    opts = function()
+      require("org-roam").setup({
+        directory = "~/org",
+        bindings = {
+          prefix = "<Leader>r",
+        },
+        extensions = {
+          dailies = {
+            directory = "0-inbox",
+          },
+        },
+      })
+    end,
+  }
+}


### PR DESCRIPTION
Adds minimal config for [nvim-orgmode](https://github.com/nvim-orgmode/orgmode) and [org-roam.nvim](https://github.com/chipsenkbeil/org-roam.nvim/).